### PR TITLE
chore: add Claude Code permission settings for safer YOLO mode

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,42 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mkdir:*)",
+      "Bash(npm create:*)",
+      "Bash(npm install)",
+      "Bash(npm install:*)",
+      "Bash(npm run:*)",
+      "Bash(python:*)",
+      "Bash(python3:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)",
+      "Bash(git pull:*)",
+      "Bash(git merge:*)",
+      "Bash(curl:*)",
+      "Bash(touch:*)",
+      "Bash(chmod:*)",
+      "Bash(source:*)",
+      "Bash(pip install:*)",
+      "Bash(docker:*)",
+      "Bash(docker-compose:*)",
+      "Read",
+      "Edit",
+      "Write",
+      "Grep",
+      "Glob",
+      "LS"
+    ],
+    "deny": [
+      "Bash(git push:*)",
+      "Bash(rm:*)",
+      "Bash(rm -rf:*)",
+      "Bash(git rm:*)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` to configure Claude Code tool permissions
- Enable YOLO mode for common safe operations while blocking dangerous ones
- Improve development workflow safety without sacrificing productivity

## Changes
- **Allow without approval**: Most git operations, npm, python, docker commands, file read/edit
- **Block (require approval)**: `git push`, file removal (`rm`, `git rm`)

## Test plan
- [x] Claude Code respects the settings file
- [x] Common operations work without approval prompts
- [x] Dangerous operations still require explicit confirmation

🤖 Generated with [Claude Code](https://claude.ai/code)