### PR TITLE
Fix: Disable Enter key submission for text input

### DIFF
--- a/apps/web/src/components/VideoFeed.tsx
+++ b/apps/web/src/components/VideoFeed.tsx
@@ -319,7 +319,6 @@ export const VideoFeed: React.FC<VideoFeedProps> = ({
               : `Current: "${promptToUse.substring(0, 40)}${promptToUse.length > 40 ? '...' : ''}"`}
             value={customPrompt}
             onChange={(e) => setCustomPrompt(e.target.value)}
-            onKeyPress={(e) => e.key === 'Enter' && handlePromptSubmit()}
           />
           <button
             className={`${styles.submitButton} ${promptSubmitted ? styles.submitted : ''}`}


### PR DESCRIPTION
## Summary
- Remove onKeyPress handler from custom prompt text input
- Prevent accidental form submission when Enter key is pressed
- Users must now explicitly click the submit button to submit prompts

## Test plan
- [ ] Verify Enter key no longer triggers form submission in text input
- [ ] Verify submit button still works correctly
- [ ] Test that form validation still works (disabled state when input is empty)

🤖 Generated with [Claude Code](https://claude.ai/code)