### PR TITLE
Fix periodic capture interval issues in React StrictMode

### DIFF
--- a/apps/web/src/components/VideoFeed.tsx
+++ b/apps/web/src/components/VideoFeed.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState, useCallback } from 'react';
+import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { usePeriodicCapture } from '../hooks/usePeriodicCapture';
 import { useSSE, AIAnalysis } from '../hooks/useSSE';
 import { AIAnalysisOverlay } from './AIAnalysisOverlay';
@@ -49,8 +49,8 @@ export const VideoFeed: React.FC<VideoFeedProps> = ({
   const [showSuccessToast, setShowSuccessToast] = useState<boolean>(false);
   const [successHiding, setSuccessHiding] = useState<boolean>(false);
 
-  // Example prompts for placeholder
-  const examplePrompts = [
+  // Example prompts for placeholder (defined outside component or memoized to prevent recreating)
+  const examplePrompts = useMemo(() => [
     "Is he smiling?",
     "Are they waving?", 
     "Is someone sleeping?",
@@ -61,7 +61,7 @@ export const VideoFeed: React.FC<VideoFeedProps> = ({
     "Are they talking?",
     "Is someone eating?",
     "Are they sitting?"
-  ];
+  ], []);
 
   const [currentExample, setCurrentExample] = useState<string>(() => 
     examplePrompts[Math.floor(Math.random() * examplePrompts.length)]

--- a/apps/web/src/hooks/usePeriodicCapture.ts
+++ b/apps/web/src/hooks/usePeriodicCapture.ts
@@ -101,7 +101,7 @@ export function usePeriodicCapture({
     } catch (error) {
       console.error('Error capturing frame:', error);
     }
-  }, [videoElement, customPrompt, onAnalysisStart, captureCount]);
+  }, [videoElement, customPrompt, onAnalysisStart, captureCount, intervalSeconds]);
   
   // Start periodic capture
   const startCapture = useCallback(() => {
@@ -144,9 +144,16 @@ export function usePeriodicCapture({
   // Auto start/stop based on isActive prop
   useEffect(() => {
     if (isActive && videoElement && customPrompt) {
+      // Prevent double execution in React.StrictMode
+      if (intervalRef.current) {
+        return;
+      }
+      
       // Small delay to ensure video is ready
       const timeout = setTimeout(() => {
-        startCapture();
+        if (!intervalRef.current) {  // Double check before starting
+          startCapture();
+        }
       }, 500);
       
       return () => {
@@ -154,9 +161,12 @@ export function usePeriodicCapture({
         stopCapture();
       };
     } else {
-      stopCapture();
+      if (intervalRef.current) {
+        stopCapture();
+      }
     }
-  }, [isActive, videoElement, customPrompt, startCapture, stopCapture]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isActive, videoElement, customPrompt, intervalSeconds]);
   
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixed the issue where frames were being captured too frequently (every ~1 second instead of every 5 seconds)
- Resolved React StrictMode double execution problems
- Stabilized the periodic capture interval behavior

## Problem
The periodic frame capture was triggering much more frequently than the configured 5-second interval. This was causing:
- Excessive API calls to the LLaVA analysis endpoint
- Rapid changes in the UI placeholder text ("Try: xxxx")  
- Poor user experience with constantly changing prompts

## Root Causes
1. **React StrictMode** was causing effects to run twice in development mode
2. **Unmemoized arrays** were causing unnecessary re-renders and effect re-runs
3. **Function dependencies** in useEffect were causing the effect to restart on every render

## Solution
- **Memoized `examplePrompts` array** to prevent recreation on every render
- **Added interval ref checks** to prevent multiple intervals from being created
- **Removed function dependencies** from the useEffect to prevent unnecessary re-runs
- **Added double-checks** before starting capture to handle StrictMode behavior

## Test Plan
- [x] Verified frames are captured every 5 seconds (not faster)
- [x] Confirmed placeholder text changes only when frames are captured
- [x] Tested with React StrictMode enabled (development mode)
- [x] Verified no duplicate intervals are created
- [x] Checked browser console for proper timing logs

🤖 Generated with [Claude Code](https://claude.ai/code)